### PR TITLE
Remove padding from the blog page container & change name from Frappé to Frappe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.egg-info
 *.swp
 tags
+.kdev4/
+*.kdev4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Frappé Framework
+## Frappe Framework
 
 frappe.io
 

--- a/frappe_io/hooks.py
+++ b/frappe_io/hooks.py
@@ -15,7 +15,7 @@ required_apps = ["frappe_theme"]
 fixtures = ["Contact Us Settings", "Web Form", "Email Alert"]
 
 website_context = {
-	"brand_html": "<img class='navbar-icon' src='/assets/frappe_theme/img/frappe-bird-grey.svg' />Frappé",
+	"brand_html": "<img class='navbar-icon' src='/assets/frappe_theme/img/frappe-bird-grey.svg' />Frappe",
 	"top_bar_items": [
 		{"label": "Documentation", "url": "/docs", "right":1, "target": "_blank"},
 		{"label": "About", "url":"/about", "right": 1},

--- a/frappe_io/templates/includes/blog/blog.html
+++ b/frappe_io/templates/includes/blog/blog.html
@@ -8,7 +8,7 @@
 	        <img class="erp-hero" src="/assets/frappe_theme/img/bulb.svg" style="width: 200px;">
 	    </div>
 	    <div class="col-sm-12 hero-content" style="margin-top: -50px;">
-	        <h1>Frappé Blog</h1>
+	        <h1>Frappe Blog</h1>
 	        <p>A blog about ideas, inspiration and intent</p>
 	    </div>
 	</div>

--- a/frappe_io/templates/includes/custom.css
+++ b/frappe_io/templates/includes/custom.css
@@ -23,7 +23,6 @@ article table {
 .page-container[data-doctype="Blog Post"], .page-container[data-path="blog"] {
 	max-width: 660px;
 	margin: auto;
-	padding-top: 60px;
 }
 
 @media (max-width: 767px) {

--- a/frappe_io/templates/includes/footer/footer.html
+++ b/frappe_io/templates/includes/footer/footer.html
@@ -7,7 +7,7 @@
                         <a href="https://erpnext.com">ERPNext</a>
                     </li>
                     <li>
-                        <a href="https://frappe.io">Frappé</a>
+                        <a href="https://frappe.io">Frappe</a>
                     </li>
                     <li>
                         <a href="https://frappe.io/blog">Blog</a>
@@ -39,14 +39,14 @@
                     target="_blank">Twitter</a>,
                 <a class="underline" href="https://www.facebook.com/ERPNext/"
                     target="_blank">Facebook</a>,
-                <a class="underline" href="https://medium.com/frappé-thoughts/"
+                <a class="underline" href="https://medium.com/frappe-thoughts/"
                     target="_blank">Medium</a>
             </p>
         </div>
 
         <div class="copyright">
             <p>
-                &copy;<span id="year"></span> Frappé Technologies Pvt. Ltd.
+                &copy;<span id="year"></span> Frappe Technologies Pvt. Ltd.
                 Content licensed under
                 <a class="underline" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">
                     CC-BY-SA 3.0</a>. Read the <a href="https://erpnext.com/terms" class="underline">terms of use</a>.

--- a/frappe_io/www/about.html
+++ b/frappe_io/www/about.html
@@ -9,8 +9,8 @@
         <img class="frappe-hero" src="/assets/frappe_theme/img/frappe-hero.svg">
     </div>
     <div class="col-sm-12 hero-content">
-        <h1>Frappé &mdash; The Company</h1>
-        <p class='lead text-muted'>Established in 2008, Frappé is an internet company based out of Mumbai, India. Its flagship product ERPNext is an award-winning and easy to use ERP loved by businesses worldwide.</p>
+        <h1>Frappe &mdash; The Company</h1>
+        <p class='lead text-muted'>Established in 2008, Frappe is an internet company based out of Mumbai, India. Its flagship product ERPNext is an award-winning and easy to use ERP loved by businesses worldwide.</p>
         <a href="/story">Read the full story.</a>
     </div>
 </div>
@@ -22,7 +22,7 @@
         </div>
         <div class="col-sm-8 content text-center-xs">
             <h1 style="margin-top: 0px;">Serious About Open Source</h1>
-            <p>Frappé products and the web framework have a thriving open source community. Developers and service providers participate from over 44 countries and are relentless about building ERP ecosystems.</p>
+            <p>Frappe products and the web framework have a thriving open source community. Developers and service providers participate from over 44 countries and are relentless about building ERP ecosystems.</p>
             <a href="https://discuss.erpnext.com">Join the Community</a>
         </div>
     </div>
@@ -31,7 +31,7 @@
 <div class="group">
     <div class="row hero">
 	    <div class="col-sm-12 hero-content">
-	        <h1>Team Frappé</h1>
+	        <h1>Team Frappe</h1>
 	        <p>We love to build new things and break them apart, and build them again</p>
 	    </div>
 		<div class='col-sm-12' style='margin-top: 30px;'>

--- a/frappe_io/www/index.html
+++ b/frappe_io/www/index.html
@@ -5,7 +5,7 @@
             <img class="developers-hero" src="/assets/frappe_theme/img/developers-hero.svg">
         </div>
         <div class="col-sm-12 hero-content">
-            <h1>Frappé for Developers</h1>
+            <h1>Frappe for Developers</h1>
             <p class='lead text-muted'>A full-stack web framework based on Python and Javascript to help you build powerful business apps and nifty extensions.</p>
             <a class="x-large blue button" href="https://frappe.io/docs/user/">Learn Frappe</a>
         </div>
@@ -18,8 +18,8 @@
                 <img src="/assets/frappe_theme/img/developers-erp-framework.svg" class="img-responsive erp-framework">
             </div>
             <div class="col-sm-7 col-sm-pull-5 content">
-                <h1>ERPNext + Frappé Framework</h1>
-                <p>ERPNext is built entirely on the Frappé framework. This extensible framework allows you to customize and fine tune ERPNext to best suit your business workflow.</p>
+                <h1>ERPNext + Frappe Framework</h1>
+                <p>ERPNext is built entirely on the Frappe framework. This extensible framework allows you to customize and fine tune ERPNext to best suit your business workflow.</p>
                 <a href="https://frappe.io/docs/user/">Read the Documentation</a>
             </div>
 
@@ -31,13 +31,13 @@
             <div class="col-sm-4 small-content">
                 <img src="/assets/frappe_theme/img/developers-community.svg">
                 <h1>Community</h1>
-                <p>Frappé connects business users with service providers and web developers who specialize in ERP systems.</p>
+                <p>Frappe connects business users with service providers and web developers who specialize in ERP systems.</p>
                 <a href="https://erpnext.org/service-providers" target="_blank">Learn More</a>
             </div>
 
             <div class="col-sm-4 small-content">
                 <img src="/assets/frappe_theme/img/developers-apps.svg">
-                <h1>Frappé Apps</h1>
+                <h1>Frappe Apps</h1>
                 <p>Contributions drive the open source ecosystem. A showcase of Frappe apps built by amazing fellow developers.</p>
                 <a href="https://erpnext.org/apps" target="_blank">View Apps</a>
             </div>
@@ -45,7 +45,7 @@
             <div class="col-sm-4 small-content">
                 <img src="/assets/frappe_theme/img/developers-training.svg">
                 <h1>Consulting</h1>
-                <p>Frappé offers special consulting programs for businesses who want in-house capabilities in building and managing their ERP systems.</p>
+                <p>Frappe offers special consulting programs for businesses who want in-house capabilities in building and managing their ERP systems.</p>
                 <a href="https://erpnext.com/pricing/vip" target="_blank">Learn More</a>
             </div>
         </div>

--- a/frappe_io/www/jobs.md
+++ b/frappe_io/www/jobs.md
@@ -2,7 +2,7 @@
 
 <!-- no-sidebar -->
 
-<p class="lead">Frappé Technologies Pvt Ltd is a Mumbai based Open Source Software Development Company.</p>
+<p class="lead">Frappe Technologies Pvt Ltd is a Mumbai based Open Source Software Development Company.</p>
 
 If you are passionate, obsessive and persistent Software Developer, Designer or Writer, someone who believes in the long term, values quality and believes that honesty is above everything else, we want to know you.
 

--- a/frappe_io/www/story.md
+++ b/frappe_io/www/story.md
@@ -34,14 +34,14 @@ What helps us is that we have decided to monetize only from our hosting services
 
 We believe we have today a very usable and robust ERP system for small businesses. Even large businesses can use it, but we are not particlarly interested in that avenue because it would require services, and we are happy to let independent vendors do that. Our project has reached a reasonable community size and we can feel there is a good momentum with the number of users who are evaluating the product every day.
 
-We need to focus on making things even easier for the end user and providing adequate documetation for the developer. Our framework Frappé, allows rapid application development and provides a platform to create apps or extensions to the product. With most of the basics in place, we think the ERP market is poised for a major disruption in the next five years.
+We need to focus on making things even easier for the end user and providing adequate documetation for the developer. Our framework Frappe, allows rapid application development and provides a platform to create apps or extensions to the product. With most of the basics in place, we think the ERP market is poised for a major disruption in the next five years.
 
 Our biggest satisfaction will be when a whole bunch of small, local, innovative organizations across the world gets access to tools that will help them compete with large, global, and inefficient corporations—creating a level playing field that will leave our world a little bit more fair.
 
 <br>
 Rushabh Mehta<br>
 Founder<br>
-ERPNext and Frappé
+ERPNext and Frappe
 
 ---
 

--- a/frappe_io/www/terms.md
+++ b/frappe_io/www/terms.md
@@ -5,7 +5,7 @@ Version 1.01
 
 ### Introduction
 
-Frappé Technologies Pvt Ltd is the publisher of "ERPNext" and offers hosting and support services for the same. The software is available under the GNU/GPL licenses and others as specified in the source code. This agreement is not about the software (which is available under the General Public License) but for the hosting and support services that are provided commercially.
+Frappe Technologies Pvt Ltd is the publisher of "ERPNext" and offers hosting and support services for the same. The software is available under the GNU/GPL licenses and others as specified in the source code. This agreement is not about the software (which is available under the General Public License) but for the hosting and support services that are provided commercially.
 
 ### 1. Scope
 
@@ -15,7 +15,7 @@ This agreement covers the terms under which you can use the free, trial or paid 
 
 Services: Hosting and support services offered by us
 You, Your: The subscriber or user of our services
-We, Us, Our: Frappé Technologies Pvt. Ltd. or services offered by Frappé Technologies Pvt Ltd
+We, Us, Our: Frappe Technologies Pvt. Ltd. or services offered by Frappe Technologies Pvt Ltd
 Confidential Information: Information that is given from one party to another that is reasonably understood to be confidential.
 
 ### 3. Services
@@ -76,7 +76,7 @@ You can ask for your data for a period of 30 days after the termination. You wil
 
 This agreement is subject to change and we will update you via email incase we make any changes.
 
-Company: Frappé Technologies Pvt Ltd
+Company: Frappe Technologies Pvt Ltd
 
 Registered Address: D/324 Neelkanth Business Park, Vidyavihar West, Mumbai 400086
 


### PR DESCRIPTION
This PR removes excess padding from the blog page container.