### PR TITLE
Typo Fix "everwhere" to "everywhere"

### DIFF
--- a/frappe_io/www/frappe/index.html
+++ b/frappe_io/www/frappe/index.html
@@ -69,7 +69,7 @@
 	<div class='row mt-5'>
 		{{ card(
 			"Metadata First",
-			"Everything in Frappe is a DocType. DocTypes can be defined easily without code used everwhere.",
+			"Everything in Frappe is a DocType. DocTypes can be defined easily without code used everywhere.",
 		) }}
 		{{ card(
 			"Admin User Interface",


### PR DESCRIPTION
Fixed typo in doctype description