### PR TITLE
Updated link to translation portal

### DIFF
--- a/frappe_io/www/docs/user/en/guides/basics/translations.md
+++ b/frappe_io/www/docs/user/en/guides/basics/translations.md
@@ -51,7 +51,7 @@ translations loaded at the time.
 
 ### 4. Improving Translations:
 
-For updating translations, please go to the to [the translation portal](https://frappe.io/translator).
+For updating translations, please go to the to [the translation portal](https://translate.erpnext.com).
 
 If you want to do it directly via code:
 


### PR DESCRIPTION
https://frappe.io/translator -> https://translate.erpnext.com

Will fix this error: "Not Found. You seem to have hit a broken link. This page does not exist."