### PR TITLE
Documentation corrections

### DIFF
--- a/frappe_io/www/docs/user/en/guides/app-development/overriding-link-query-by-custom-script.md
+++ b/frappe_io/www/docs/user/en/guides/app-development/overriding-link-query-by-custom-script.md
@@ -3,7 +3,7 @@
 
 You can override the standard link query by using `set_query`
 
-### 1. Adding Fitlers
+### 1. Adding Filters
 
 You can add filters to the query:
 

--- a/frappe_io/www/docs/user/en/guides/basics/apps.md
+++ b/frappe_io/www/docs/user/en/guides/basics/apps.md
@@ -9,7 +9,7 @@ and must have an entry in the `apps.txt` file.
 
 ### Creating an app
 
-Frappe ships with a boiler plate for a new app. The command `bench make-app
+Frappe ships with a boiler plate for a new app. The command `bench new-app
 app-name` helps you start a new app by starting an interactive shell.
 
 

--- a/frappe_io/www/docs/user/en/guides/basics/hooks.md
+++ b/frappe_io/www/docs/user/en/guides/basics/hooks.md
@@ -237,7 +237,7 @@ Eg,
 
 	doc_events = {
 		"Cab Request": {
-			"after_insert": topcab.schedule_cab",
+			"after_insert": "topcab.schedule_cab",
 		}
 	}
 

--- a/frappe_io/www/docs/user/en/guides/basics/site_config.md
+++ b/frappe_io/www/docs/user/en/guides/basics/site_config.md
@@ -29,7 +29,8 @@ Example:
 ### Remote Database Host Settings
 - `db_host`: Database host if not `localhost`.
 
-To connect to a remote database server using ssl, you must first configure the database host to accept SSL connections. An example of how to do this is available at https://www.digitalocean.com/community/tutorials/how-to-configure-ssl-tls-for-mysql-on-ubuntu-16-04. After you do the configuration, set the following three options. All options must be set for Frappe to attempt to connect using SSL.
+To connect to a remote database server using ssl, you must first configure the database host to accept SSL connections. An example of how to do this is available at [this tutorial by Digital Ocean](https://www.digitalocean.com/community/tutorials/how-to-configure-ssl-tls-for-mysql-on-ubuntu-16-04). After you do the configuration, set the following three options. All options must be set for Frappe to attempt to connect using SSL.
+
 - `db_ssl_ca`: Full path to the ca.pem file used for connecting to a database host using ssl. Example value is `"/etc/mysql/ssl/ca.pem"`.
 - `db_ssl_cert`: Full path to the cert.pem file used for connecting to a database host using ssl. Example value is `"/etc/mysql/ssl/client-cert.pem"`.
 - `db_ssl_key`: Full path to the key.pem file used for connecting to a database host using ssl. Example value is `"/etc/mysql/ssl/client-key.pem"`.

--- a/frappe_io/www/docs/user/en/guides/basics/sites.md
+++ b/frappe_io/www/docs/user/en/guides/basics/sites.md
@@ -80,7 +80,7 @@ starting it with the following command.
 
 ### Adding a new site
 
-To add a new site, execute the following command in your bench instance :
+To add a new site, execute the following command in your bench instance:
 
 `bench new-site SITENAME`
 

--- a/frappe_io/www/docs/user/en/guides/basics/sites.md
+++ b/frappe_io/www/docs/user/en/guides/basics/sites.md
@@ -4,7 +4,7 @@
 ## Sites Directory
 
 Frappe is a multitenant platform and each tenant is called a site. Sites exist
-in a directory called `sites_dir`, assumed as the current working directory when
+in a directory called `sites`, assumed as the current working directory when
 running a frappe command or other services like Celery worker or a WSGI server.
 
 You can set `sites_dir` with an environment variable `SITES_DIR` or pass
@@ -80,4 +80,14 @@ starting it with the following command.
 
 ### Adding a new site
 
+To add a new site, execute the following command in your bench instance :
+
 `bench new-site SITENAME`
+
+### Set a site as the current site
+
+To force a site to be used as the default site, execute the following:
+
+`bench use SITENAME`
+
+To make sure, check the contents of `currentsite.txt` (found in the `sites` folder of your bench instance) and it should have SITENAME.

--- a/frappe_io/www/docs/user/en/tutorial/start.md
+++ b/frappe_io/www/docs/user/en/tutorial/start.md
@@ -21,12 +21,12 @@ Now login with :
 
 Login ID: **Administrator**
 
-Password : **Use the password that was created during installation**
+Password : **Use the password that was set during site installation**
 
 When you login, you should see the "Desk" home page
 
 <img class="screenshot" alt="Desk" src="/docs/assets/img/desk.png">
 
-As you can see, the Frappe basic system comes with several pre-loaded applications like To Do, File Manager etc. These apps can integrated in your app workflow as we progress.
+As you can see, the Frappe basic system comes with several pre-loaded utilities like To Do, File Manager etc. These apps can integrated in your app workflow as we progress.
 
 {next}


### PR DESCRIPTION
Following corrections were made:

- The URL to the Digital Ocean tutorial was turned into a hyperlink with a display text and an extra newline added before the list to ensure it was rendered correctly.
- Minor spelling change ( from `fitlers` to `filters`)
- Corrected command from `make-app` (probably deprecated) to `new-app` (current)
- `site_dr` changed to `sites`, however not sure about the environment variable. Added new section for making a site the currentsite