### PR TITLE
Replaced "areaFill" to "regionFill" as the former doesn't work

### DIFF
--- a/frappe_io/www/charts/docs/basic/trends_regions.md
+++ b/frappe_io/www/charts/docs/basic/trends_regions.md
@@ -3,7 +3,7 @@ An area chart is derived from a line chart, by marking the area between the X ax
 
 ```js
 lineOptions: {
-	areaFill: 1 // default: 0
+	regionFill: 1 // default: 0
 },
 ```
 <project-demo data="1"
@@ -12,7 +12,7 @@ lineOptions: {
 		height: 240,
 		colors: ['violet'],
 		lineOptions: {
-			areaFill: 1
+			regionFill: 1
 		},
 	}">
 </project-demo>


### PR DESCRIPTION
Hello,

I noticed that using "areaFill" doesn't generate the fill effect as shown below:

<img width="1280" alt="screenshot 2018-11-08 at 8 35 11 pm" src="https://user-images.githubusercontent.com/498909/48207056-d3eda800-e395-11e8-81b4-b8e9a85da3bf.png">

Replacing it with "regionFill" works:

<img width="1280" alt="screenshot 2018-11-08 at 8 35 53 pm" src="https://user-images.githubusercontent.com/498909/48207088-e8ca3b80-e395-11e8-828e-1366bda10c4d.png">

Cheers,
Shesh
