### PR TITLE
[Docs] Change 'bench mysql' command to 'bench mariadb'

### DIFF
--- a/frappe_io/www/docs/user/en/tutorial/doctypes.md
+++ b/frappe_io/www/docs/user/en/tutorial/doctypes.md
@@ -55,7 +55,7 @@ Click on the **Save** button.
 
 Now login into mysql and check the database table created:
 
-	$ bench mysql
+	$ bench mariadb
 	Welcome to the MariaDB monitor.  Commands end with ; or \g.
 	Your MariaDB connection id is 3931
 	Server version: 5.5.36-MariaDB-log Homebrew


### PR DESCRIPTION
Replacing the command since ```bench mysql``` command has been deprecated and replaced by `bench mariadb`