### PR TITLE
Fix and improve introduction to API

### DIFF
--- a/frappe_io/www/docs/user/en/guides/integration/rest_api/index.md
+++ b/frappe_io/www/docs/user/en/guides/integration/rest_api/index.md
@@ -2,19 +2,31 @@
 
 # Introduction
 
-Frappe ships with an HTTP API. There are that could be classified into *Remote Procedure Calls* (RPC, call whitelisted methods) and REST (manipulate resources).
+Frappe ships with an HTTP API that can be classified into *Remote Procedure Calls* (RPC), to call whitelisted methods and *Representational State Transfer* (REST), to manipulate resources.
 
-The base URL is `https://{your frappe instance}`. A request to an endpoint `/api/method/dotted.path.to.function` will call a whitelisted python function. 
+The base URL is `https://{your frappe instance}`. Every request shown here should be added to the end of your base URL. For example, if your instance is `demo.erpnext.com`, `GET /api/resource/User` means `GET https://demo.erpnext.com/api/resource/User`.
 
-GET **/api/method/sample_app.ping**
+## RPC
+
+A request to an endpoint `/api/method/dotted.path.to.function` will call a whitelisted python function. 
+
+For example, `GET /api/method/frappe.auth.get_logged_user` will call [this function](https://github.com/frappe/frappe/blob/28b909435320e3d6d1a3b2e7c02f286984dc39b3/frappe/auth.py#L347-L349) from frappe's auth module:
+
+```python
+@frappe.whitelist()
+def get_logged_user():
+	return frappe.session.user
+```
 
 Response:
 
 ```json
 {
-  "message": "pong"
+  "message": "Administrator"
 }
 ```
+
+## REST
 
 All documents in Frappe are available via a RESTful API with prefix `/api/resource/`. You can perform all CRUD operations on them:
 


### PR DESCRIPTION
Fix grammar in first sentence, split introduction into sections "RPC" and "REST".