### PR TITLE
Escape underscores in API docs

### DIFF
--- a/frappe_io/www/docs/user/en/guides/integration/rest_api/simple_authentication.md
+++ b/frappe_io/www/docs/user/en/guides/integration/rest_api/simple_authentication.md
@@ -68,7 +68,7 @@ Returns:
 * HTTP Code: 200
 * application/json: `{}`
 
-## GET /api/method/frappe.auth.get_logged_user
+## GET /api/method/frappe.auth.get\_logged\_user
 
 Get the ID of the currently authenticated user.
 


### PR DESCRIPTION
Escape underscores to avoid inappropriate italics.

![italic_underscores](https://user-images.githubusercontent.com/14891507/48441340-90c37880-e78b-11e8-856a-f25364bcafc9.png)