### PR TITLE
Added known cmd and removed deprecated option

### DIFF
--- a/frappe_io/www/docs/user/en/bench/resources/bench-commands-cheatsheet.md
+++ b/frappe_io/www/docs/user/en/bench/resources/bench-commands-cheatsheet.md
@@ -3,6 +3,7 @@
 
 ### General Usage
 * `bench --version` - Show bench version
+* `bench version` - Show version of all apps
 * `bench src` - Show bench repo directory
 * `bench --help` - Show all commands and help
 * `bench [command] --help` - Show help for command
@@ -15,7 +16,6 @@
   * `--bench`               Update bench
   * `--requirements`        Update requirements
   * `--restart-supervisor`  restart supervisor processes after update
-  * `--upgrade` Does major upgrade (Eg. ERPNext 6 -> 7)
   * `--no-backup`			  Don't take a backup before update
 * `bench restart` Restart all bench services 
 * `bench backup` Backup 


### PR DESCRIPTION
Added `bench version` to the cheatsheet

Removed `--upgrade` option as it has been deprecated (For reference : [nabinhait's reply on a Discuss thread](https://discuss.erpnext.com/t/erpnext-version-9-will-be-released-on-26th-september-2017/28586/22?u=root13f))