### PR TITLE
docs: added max_reports_per_user in site_config

### DIFF
--- a/frappe_io/www/docs/user/en/guides/basics/site_config.md
+++ b/frappe_io/www/docs/user/en/guides/basics/site_config.md
@@ -25,6 +25,7 @@ Example:
 - `mute_emails`: Stops email sending if true.
 - `deny_multiple_logins`: Stop users from having more than one active session.
 - `root_password`: MariaDB root password.
+- `max_reports_per_user`: Maximum number of Auto Email Reports which can be created by a user, default is 3
 
 ### Remote Database Host Settings
 - `db_host`: Database host if not `localhost`.


### PR DESCRIPTION
max_reports_per_user indicates the maximum number of Auto Email Reports
which can created by a user. The defult value for the same is 3, however
it can be configured via the site_config of the site