### PR TITLE
Fix docs about barOptions.spaceRatio max value

### DIFF
--- a/frappe_io/www/charts/docs/reference/configuration.md
+++ b/frappe_io/www/charts/docs/reference/configuration.md
@@ -165,7 +165,7 @@ Can be used to set various properties on bar plots.
 #### spaceRatio
  - Type: `Number`
  - Min: `0`
- - Max: `2`
+ - Max: `1`
  - Default: `0.5`
 
 In order to set the bar width, instead of defining it and the space between the bars independently, we simply define the <b>ratio of the space</b> between bars to the bar width. The chart then adjusts the actual size proportional to the chart container.


### PR DESCRIPTION
I recognized a small error in the documentation: `barOptions.spaceRatio` max value is 1 and not 2. Using a value over 1 always throws an error. e.g. `Error: <rect> attribute width: A negative value is not valid. ("-11.742857142857153")`