### PR TITLE
docs: Fix set_query for child table fields

### DIFF
--- a/frappe_io/www/docs/user/en/api/form.md
+++ b/frappe_io/www/docs/user/en/api/form.md
@@ -377,7 +377,7 @@ frm.set_query('customer', () => {
 
 // set filters for Link field item_code in
 // items field which is a Child Table
-frm.set_query('items', 'item_code', () => {
+frm.set_query('item_code', 'items', () => {
 	return {
 		filters: {
 			item_group: 'Products'


### PR DESCRIPTION
The correct order is `{fieldname}` on which you want to apply filter and then the `{child_table_fieldname}`