### PR TITLE
Missing step for the next section

### DIFF
--- a/frappe_io/www/docs/user/en/tutorial/bench.md
+++ b/frappe_io/www/docs/user/en/tutorial/bench.md
@@ -9,4 +9,23 @@ With Frappe Bench you will be able to setup and host multiple applications and s
 
 The `bench` command line tool will also be installed that will help you in development and management of the installation.
 
+## Create a new bench
+
+The init command will create a bench directory with frappe framework installed. It will be setup for periodic backups and auto updates once a day.
+
+        $ bench init frappe-bench && cd frappe-bench
+        INFO:bench.utils:virtualenv -q env -p /usr/bin/python3
+        Already using interpreter /usr/bin/python3
+        INFO:bench.utils:env/bin/pip -q install --upgrade pip
+        INFO:bench.utils:env/bin/pip -q install wheel
+        .
+        .
+        ✨  Done in 102.992s
+        Done in 104.04s.
+        INFO:bench.utils:setting up backups
+        INFO:bench.utils:setting up auto update
+        Bench frappe-bench initialized
+
+        
+
 {next}


### PR DESCRIPTION
Please add the bench init step, I was not able to follow it, it felt like disconnect because the next step (https://frappe.io/docs/user/en/tutorial/new-app) wasn't working. I had to look somewhere else for the answer.