### PR TITLE
Fix doc_events hooks documentation

### DIFF
--- a/frappe_io/www/docs/user/en/guides/basics/hooks.md
+++ b/frappe_io/www/docs/user/en/guides/basics/hooks.md
@@ -211,7 +211,7 @@ To hook to events of all doctypes, you can use the follwing syntax also,
 		}
 	 }
 
-The hook function will be passed the doc in concern as the only argument.
+The hook function will be passed the doc in concern and the event name as the two arguments.
 
 ##### List of events
 
@@ -239,6 +239,10 @@ Eg,
 			"after_insert": "topcab.schedule_cab",
 		}
 	}
+	
+Will call:
+
+	topcab.schedule_cab(cab_request_doc, 'after_insert')
 
 ### Scheduler Hooks
 


### PR DESCRIPTION
Currently the documentation says that the `doc` object will be the only parameter. However, as of Frappe 12.3.0, the `event name` is  also passed as a parameter.