### PR TITLE
fix: Replace link of Team (/team)

### DIFF
--- a/frappe_io/templates/includes/footer/footer.html
+++ b/frappe_io/templates/includes/footer/footer.html
@@ -44,7 +44,7 @@
                     <a href="https://erpnext.com" class="text-muted">ERPNext</a>
                 </li>
                 <li class="py-2">
-                    <a href="https://frappe.io/about" class="text-muted">Team</a>
+                    <a href="https://frappe.io/team" class="text-muted">Team</a>
                 </li>
                 <li class="py-2">
                     <a href="https://frappe.io/careers" class="text-muted">Careers</a>


### PR DESCRIPTION
New page for Team: https://frappe.io/team