### PR TITLE
docs: Add info for no trailing space in translatable string

### DIFF
--- a/frappe_io/www/docs/user/en/translations.md
+++ b/frappe_io/www/docs/user/en/translations.md
@@ -195,6 +195,21 @@ else:
   msg = _("You have {0} pending invoice").format(invoice_count)
 ```
 
+### 4. No Trailing Spaces
+
+Don't start or end the sentence with spaces.
+
+```py
+# Don't do this
+msg = _(" You have {0} pending invoice ")
+
+# Trailing spaces gets trimmed for other languages when passed through translation engine.
+
+# If you have to add space around your text, you can do it outside the translation syntax.
+msg = ' ' + _("You have {0} pending invoices") + ' '
+
+```
+
 ## Adding a New Language
 
 To add a new language, follow these steps:

--- a/frappe_io/www/docs/user/en/translations.md
+++ b/frappe_io/www/docs/user/en/translations.md
@@ -197,15 +197,16 @@ else:
 
 ### 4. No Trailing Spaces
 
-Don't start or end the sentence with spaces.
+Don't start or end the sentence with spaces. Trailing spaces gets trimmed for other languages when passed through translation engine.
 
 ```py
 # Don't do this
 msg = _(" You have {0} pending invoice ")
+```
+If you have to add space around your text, you can do it outside the translation syntax.
 
-# Trailing spaces gets trimmed for other languages when passed through translation engine.
-
-# If you have to add space around your text, you can do it outside the translation syntax.
+```py
+# Do this
 msg = ' ' + _("You have {0} pending invoices") + ' '
 
 ```

--- a/frappe_io/www/docs/user/en/translations.md
+++ b/frappe_io/www/docs/user/en/translations.md
@@ -199,16 +199,14 @@ else:
 
 Don't start or end the sentence with spaces. Trailing spaces gets trimmed for other languages when passed through translation engine.
 
-```py
-# Don't do this
-msg = _(" You have {0} pending invoice ")
-```
 If you have to add space around your text, you can do it outside the translation syntax.
 
 ```py
+# Don't do this
+msg = _(" You have {0} pending invoice ")
+
 # Do this
 msg = ' ' + _("You have {0} pending invoices") + ' '
-
 ```
 
 ## Adding a New Language


### PR DESCRIPTION
Add info for no trailing space in translatable string.