### PR TITLE
Added Frappe Cloud to list of Products on Frappe.io

### DIFF
--- a/frappe_io/www/index.html
+++ b/frappe_io/www/index.html
@@ -30,6 +30,11 @@
 				"url": "/frappe"
 			},
 			{
+				"title": "Cloud",
+				"content": "Server management tool and dedicated hosting service for sites that run ERPNext and Frappe apps",
+				"url": "https://frappe.cloud"
+			},
+			{
 				"title": "Accounting",
 				"content": "Offline Accounting software for everyone, with Invoicing, Payments and Reports.",
 				"url": "/accounting"


### PR DESCRIPTION
Added Frappe Cloud in this list

<img width="951" alt="Screenshot 2020-04-30 at 6 26 54 PM" src="https://user-images.githubusercontent.com/910238/80716251-0d2f5000-8b15-11ea-9f50-a9291583e986.png">

For now, there is no page on frappe.io for Frappe Cloud. Please check if URL can be improved to one link for Accounting.