### PR TITLE
fix: check request object

### DIFF
--- a/frappe_io/website_context.py
+++ b/frappe_io/website_context.py
@@ -6,6 +6,9 @@ import frappe
 
 
 def get_context(context):
+	if not frappe.request:
+		return
+
 	path = frappe.request.path
 
 	if path.startswith("/"):


### PR DESCRIPTION
**Fixes**
When this context updation gets executed via a background job(ex.print format for invoicing) it breaks during runtime with ``` RuntimeError: no object bound to request ```