### PR TITLE
chore: remove unnecessary charts js

### DIFF
--- a/frappe_io/hooks.py
+++ b/frappe_io/hooks.py
@@ -34,7 +34,7 @@ website_context = {
 # app_include_js = "/assets/frappe_io/js/frappe_io.js"
 
 # include js, css files in header of web template
-web_include_js = ["charts-demo.bundle.js"]
+#web_include_js = ["charts-demo.bundle.js"]
 web_include_css = "assets/frappe/css/hljs-night-owl.css"
 look_for_sidebar_json = True
 

--- a/frappe_io/www/charts/index.html
+++ b/frappe_io/www/charts/index.html
@@ -1,6 +1,7 @@
 {% extends "templates/base.html" %}
 {% block title %}Frappe Charts: Simple and Modern SVG Charts{% endblock %}
 {% block content %}
+<script defer src="../../public/docs/charts.js"></script>
 <link rel="stylesheet" type="text/css" href="charts/assets/css/index.css" media="screen">
 
 {{ web_blocks([


### PR DESCRIPTION
- Fix is attempted without any preview/testing 
- Will need to move project files around if this works to prevent all the directory backtracking for imports of the script
- TODO: Check if frappe charts is needed in package.json 